### PR TITLE
Fix the hover offset

### DIFF
--- a/src/elements/condition_action.py
+++ b/src/elements/condition_action.py
@@ -40,9 +40,9 @@ class ConditionAction:
         self.difference_y = 0
         self.action_text = action
         self.condition_text = condition
-
+        self.borderwidth = 0
         self.frame_id = ttk.Frame(
-            project_manager.canvas, relief=tk.FLAT, borderwidth=0, padding=padding, style="Window.TFrame"
+            project_manager.canvas, relief=tk.FLAT, borderwidth=self.borderwidth, padding=padding, style="Window.TFrame"
         )
         self.condition_label = ttk.Label(
             self.frame_id,
@@ -164,8 +164,16 @@ class ConditionAction:
         # The binding for 'Motion' must be added with '+', as 'store_mouse_position' is also bound to 'Motion':
         self.canvas_enter_func_id = project_manager.canvas.bind("<Motion>", lambda event: self._deactivate_frame(), "+")
 
+    def _set_borderwidth(self, borderwidth: int, style: str) -> None:
+        diff = self.borderwidth - borderwidth
+        self.borderwidth = borderwidth
+        self.frame_id.configure(borderwidth=borderwidth, style=style)
+        # Compensate for the borderwidth of the frame.
+        pos = project_manager.canvas.coords(self.window_id)
+        project_manager.canvas.coords(self.window_id, (pos[0] + diff, pos[1]))
+
     def _select_window(self) -> None:
-        self.frame_id.configure(borderwidth=1, style="WindowSelected.TFrame")
+        self._set_borderwidth(1, "WindowSelected.TFrame")
         self.condition_label.configure(style="WindowSelected.TLabel")
         self.action_label.configure(style="WindowSelected.TLabel")
 
@@ -179,7 +187,7 @@ class ConditionAction:
 
     def _deselect_window(self) -> None:
         project_manager.canvas.focus_set()  # "unfocus" the Text, when the mouse leaves the text.
-        self.frame_id.configure(borderwidth=0, style="Window.TFrame")
+        self._set_borderwidth(0, style="Window.TFrame")
         self.condition_label.configure(style="Window.TLabel")
         self.action_label.configure(style="Window.TLabel")
 

--- a/src/elements/global_actions_clocked.py
+++ b/src/elements/global_actions_clocked.py
@@ -27,8 +27,9 @@ class GlobalActionsClocked:
         self.text_after_content = None
         self.difference_x = 0
         self.difference_y = 0
+        self.borderwidth = 0
         self.frame_id = ttk.Frame(
-            project_manager.canvas, relief=tk.FLAT, borderwidth=0, padding=padding, style="GlobalActionsWindow.TFrame"
+            project_manager.canvas, relief=tk.FLAT, borderwidth=self.borderwidth, padding=padding, style="GlobalActionsWindow.TFrame"
         )
         self.label_before = ttk.Label(
             self.frame_id,
@@ -134,13 +135,21 @@ class GlobalActionsClocked:
         # To ensure this, save_in_file() waits for idle.
         self.text_after_content = self.text_after_id.get("1.0", tk.END)
 
+    def _set_borderwidth(self, borderwidth: int, style: str) -> None:
+        diff = self.borderwidth - borderwidth
+        self.borderwidth = borderwidth
+        self.frame_id.configure(borderwidth=borderwidth, style=style)
+        # Compensate for the borderwidth of the frame.
+        pos = project_manager.canvas.coords(self.window_id)
+        project_manager.canvas.coords(self.window_id, (pos[0] + diff, pos[1]))
+
     def activate_frame(self) -> None:
         self.activate_window()
         self.text_before_content = self.text_before_id.get("1.0", tk.END)
         self.text_after_content = self.text_after_id.get("1.0", tk.END)
 
     def activate_window(self) -> None:
-        self.frame_id.configure(borderwidth=1, style="GlobalActionsWindowSelected.TFrame")
+        self._set_borderwidth(1, "GlobalActionsWindowSelected.TFrame")
         self.label_before.configure(style="GlobalActionsWindowSelected.TLabel")
         self.label_after.configure(style="GlobalActionsWindowSelected.TLabel")
 
@@ -153,7 +162,7 @@ class GlobalActionsClocked:
 
     def deactivate_window(self) -> None:
         project_manager.canvas.focus_set()  # "unfocus" the Text, when the mouse leaves the text.
-        self.frame_id.configure(borderwidth=0, style="GlobalActionsWindow.TFrame")
+        self._set_borderwidth(0, style="GlobalActionsWindow.TFrame")
         self.label_before.configure(style="GlobalActionsWindow.TLabel")
         self.label_after.configure(style="GlobalActionsWindow.TLabel")
 

--- a/src/elements/global_actions_combinatorial.py
+++ b/src/elements/global_actions_combinatorial.py
@@ -25,9 +25,9 @@ class GlobalActionsCombinatorial:
         self.text_content = None
         self.difference_x = 0
         self.difference_y = 0
-
+        self.borderwidth = 0
         self.frame_id = ttk.Frame(
-            project_manager.canvas, relief=tk.FLAT, borderwidth=0, padding=padding, style="GlobalActionsWindow.TFrame"
+            project_manager.canvas, relief=tk.FLAT, borderwidth=self.borderwidth, padding=padding, style="GlobalActionsWindow.TFrame"
         )
         self.label = ttk.Label(
             self.frame_id,
@@ -88,12 +88,20 @@ class GlobalActionsCombinatorial:
         # To ensure this, save_in_file() waits for idle.
         self.text_content = self.text_id.get("1.0", tk.END)
 
+    def _set_borderwidth(self, borderwidth: int, style: str) -> None:
+        diff = self.borderwidth - borderwidth
+        self.borderwidth = borderwidth
+        self.frame_id.configure(borderwidth=borderwidth, style=style)
+        # Compensate for the borderwidth of the frame.
+        pos = project_manager.canvas.coords(self.window_id)
+        project_manager.canvas.coords(self.window_id, (pos[0] + diff, pos[1]))
+
     def activate_frame(self) -> None:
         self.activate_window()
         self.text_content = self.text_id.get("1.0", tk.END)
 
     def activate_window(self) -> None:
-        self.frame_id.configure(borderwidth=1, style="GlobalActionsWindowSelected.TFrame")
+        self._set_borderwidth(1, "GlobalActionsWindowSelected.TFrame")
         self.label.configure(style="GlobalActionsWindowSelected.TLabel")
 
     def deactivate_frame(self) -> None:
@@ -103,7 +111,7 @@ class GlobalActionsCombinatorial:
 
     def deactivate_window(self) -> None:
         project_manager.canvas.focus_set()  # "unfocus" the Text, when the mouse leaves the text.
-        self.frame_id.configure(borderwidth=0, style="GlobalActionsWindow.TFrame")
+        self._set_borderwidth(0, style="GlobalActionsWindow.TFrame")
         self.label.configure(style="GlobalActionsWindow.TLabel")
 
     def move_to(self, event_x, event_y, first) -> None:

--- a/src/elements/state_action.py
+++ b/src/elements/state_action.py
@@ -35,9 +35,13 @@ class StateAction:
         self.text_content = None
         self.difference_x = 0
         self.difference_y = 0
-
+        self.borderwidth = 0
         self.frame_id = ttk.Frame(
-            project_manager.canvas, relief=tk.FLAT, borderwidth=0, padding=padding, style="StateActionsWindow.TFrame"
+            project_manager.canvas,
+            relief=tk.FLAT,
+            borderwidth=self.borderwidth,
+            padding=padding,
+            style="StateActionsWindow.TFrame",
         )
         self.label_id = ttk.Label(
             self.frame_id,
@@ -97,12 +101,21 @@ class StateAction:
         # To ensure this, save_in_file() waits for idle.
         self.text_content = self.text_id.get("1.0", tk.END)
 
+    def _set_borderwidth(self, borderwidth: int, style: str) -> None:
+        diff = self.borderwidth - borderwidth
+        self.borderwidth = borderwidth
+        self.frame_id.configure(borderwidth=borderwidth, style=style)
+        # Compensate for the borderwidth of the frame.
+        # I don't know why only the x-coordinate needs compensation.
+        pos = project_manager.canvas.coords(self.window_id)
+        project_manager.canvas.coords(self.window_id, (pos[0] + diff, pos[1]))
+
     def activate_frame(self) -> None:
         self.activate_window()
         self.text_content = self.text_id.get("1.0", tk.END)
 
     def activate_window(self) -> None:
-        self.frame_id.configure(borderwidth=1, style="StateActionsWindowSelected.TFrame")
+        self._set_borderwidth(1, "StateActionsWindowSelected.TFrame")
         self.label_id.configure(style="StateActionsWindowSelected.TLabel")
 
     def deactivate_frame(self) -> None:
@@ -112,7 +125,7 @@ class StateAction:
 
     def deactivate_window(self) -> None:
         project_manager.canvas.focus_set()  # "unfocus" the Text, when the mouse leaves the text.
-        self.frame_id.configure(borderwidth=0, style="StateActionsWindow.TFrame")
+        self._set_borderwidth(0, style="StateActionsWindow.TFrame")
         self.label_id.configure(style="StateActionsWindow.TLabel")
 
     def move_to(self, event_x, event_y, first) -> None:

--- a/src/elements/state_actions_default.py
+++ b/src/elements/state_actions_default.py
@@ -26,8 +26,9 @@ class StateActionsDefault:
         self.difference_x = 0
         self.difference_y = 0
         self.move_rectangle = None
+        self.borderwidth = 0
         self.frame_id = ttk.Frame(
-            project_manager.canvas, relief=tk.FLAT, borderwidth=0, padding=padding, style="StateActionsWindow.TFrame"
+            project_manager.canvas, relief=tk.FLAT, borderwidth=self.borderwidth, padding=padding, style="StateActionsWindow.TFrame"
         )
         # Create label object inside frame:
         self.label = ttk.Label(
@@ -90,12 +91,20 @@ class StateActionsDefault:
         # To ensure this, save_in_file() waits for idle.
         self.text_content = self.text_id.get("1.0", tk.END)
 
+    def _set_borderwidth(self, borderwidth: int, style: str) -> None:
+        diff = self.borderwidth - borderwidth
+        self.borderwidth = borderwidth
+        self.frame_id.configure(borderwidth=borderwidth, style=style)
+        # Compensate for the borderwidth of the frame.
+        pos = project_manager.canvas.coords(self.window_id)
+        project_manager.canvas.coords(self.window_id, (pos[0] + diff, pos[1]))
+
     def activate_frame(self) -> None:
         self.activate_window()
         self.text_content = self.text_id.get("1.0", tk.END)
 
     def activate_window(self) -> None:
-        self.frame_id.configure(borderwidth=1, style="StateActionsWindowSelected.TFrame")
+        self._set_borderwidth(1, "StateActionsWindowSelected.TFrame")
         self.label.configure(style="StateActionsWindowSelected.TLabel")
 
     def deactivate_frame(self) -> None:
@@ -105,7 +114,7 @@ class StateActionsDefault:
 
     def deactivate_window(self) -> None:
         project_manager.canvas.focus_set()  # "unfocus" the Text, when the mouse leaves the text.
-        self.frame_id.configure(borderwidth=0, style="StateActionsWindow.TFrame")
+        self._set_borderwidth(0, style="StateActionsWindow.TFrame")
         self.label.configure(style="StateActionsWindow.TLabel")
 
     def move_to(self, event_x, event_y, first) -> None:

--- a/src/elements/state_comment.py
+++ b/src/elements/state_comment.py
@@ -32,8 +32,9 @@ class StateComment:
         self.text_content = None
         self.difference_x = 0
         self.difference_y = 0
+        self.borderwidth = 0
         self.frame_id = ttk.Frame(
-            project_manager.canvas, relief=tk.FLAT, borderwidth=0, style="StateActionsWindow.TFrame", padding=padding
+            project_manager.canvas, relief=tk.FLAT, borderwidth=self.borderwidth, style="StateActionsWindow.TFrame", padding=padding
         )
         self.label_id = ttk.Label(
             self.frame_id,
@@ -100,12 +101,20 @@ class StateComment:
         # To ensure this, save_in_file() waits for idle.
         self.text_content = self.text_id.get("1.0", tk.END)
 
+    def _set_borderwidth(self, borderwidth: int, style: str) -> None:
+        diff = self.borderwidth - borderwidth
+        self.borderwidth = borderwidth
+        self.frame_id.configure(borderwidth=borderwidth, style=style)
+        # Compensate for the borderwidth of the frame.
+        pos = project_manager.canvas.coords(self.window_id)
+        project_manager.canvas.coords(self.window_id, (pos[0] + diff, pos[1]))
+
     def activate_frame(self) -> None:
         self.activate_window()
         self.text_content = self.text_id.get("1.0", tk.END)
 
     def activate_window(self) -> None:
-        self.frame_id.configure(borderwidth=1, style="StateActionsWindowSelected.TFrame")
+        self._set_borderwidth(1, "StateActionsWindowSelected.TFrame")
         self.label_id.configure(style="StateActionsWindowSelected.TLabel")
 
     def deactivate_frame(self) -> None:
@@ -115,7 +124,7 @@ class StateComment:
 
     def deactivate_window(self) -> None:
         project_manager.canvas.focus_set()  # "unfocus" the Text, when the mouse leaves the text.
-        self.frame_id.configure(borderwidth=0, style="StateActionsWindow.TFrame")
+        self._set_borderwidth(0, style="StateActionsWindow.TFrame")
         self.label_id.configure(style="StateActionsWindow.TLabel")
 
     def move_to(self, event_x, event_y, first) -> None:


### PR DESCRIPTION
With this change the inner position of the labels and edits doesn't move around when hovered by a mouse.

The adjustment of the borderwidth changes the position of the inner content. This leads to a weird jumpy behavior. With this change, we adjust the window position slightly, so that the inner content stays at the same position on a mouse hover. (No more jumping around).