### PR TITLE
Improve Zoom handling (hotkeys & sidewise scrolling)

### DIFF
--- a/src/canvas_editing.py
+++ b/src/canvas_editing.py
@@ -20,6 +20,8 @@ from project_manager import project_manager
 
 # import inspect
 
+_abs_zoom_factor: float = 1.0
+
 
 def translate_window_event_coordinates_in_rounded_canvas_coordinates(event) -> list:
     canvas_grid_x_coordinate = project_manager.canvas.canvasx(event.x, gridspacing=project_manager.state_radius)
@@ -125,12 +127,14 @@ def zoom_minus() -> None:
 
 
 def canvas_zoom(zoom_center, zoom_factor) -> None:
+    global _abs_zoom_factor
     # Modify factor, so that fontsize is always an integer:
     fontsize_rounded_down = int(project_manager.fontsize * zoom_factor)
     if zoom_factor > 1 and fontsize_rounded_down == project_manager.fontsize:
         fontsize_rounded_down += 1
     if fontsize_rounded_down != 0:
         zoom_factor = fontsize_rounded_down / project_manager.fontsize
+        _abs_zoom_factor *= zoom_factor
         project_manager.canvas.scale(
             "all", 0, 0, zoom_factor, zoom_factor
         )  # Scaling must use xoffset=0 and yoffset=0 to preserve the gridspacing of state_radius.

--- a/src/tab_diagram.py
+++ b/src/tab_diagram.py
@@ -120,6 +120,7 @@ class TabDiagram:
         minus_button.config(command=canvas_editing.zoom_minus)
 
         canvas.bind_all("<Delete>", lambda event: canvas_delete.CanvasDelete())
+        canvas.bind("<Home>", lambda event: canvas_editing.view_all())
         canvas.bind("<Button-1>", move_handling_initialization.move_initialization)
         canvas.bind("<Motion>", canvas_delete.CanvasDelete.store_mouse_position)
         canvas.bind("<Control-MouseWheel>", canvas_editing.zoom_wheel)  # MouseWheel used at Windows.

--- a/src/tab_diagram.py
+++ b/src/tab_diagram.py
@@ -159,12 +159,17 @@ class TabDiagram:
     def _scroll_wheel(self, event) -> None:
         project_manager.grid_drawer.remove_grid()
         project_manager.canvas.scan_mark(event.x, event.y)
-        delta_y = 0
+        scroll_delta = 10.0
+        delta = 0.0
         if event.num == 5 or event.delta < 0:  # scroll down
-            delta_y = -10
+            delta = -scroll_delta * canvas_editing._abs_zoom_factor
         elif event.num == 4 or event.delta >= 0:  # scroll up
-            delta_y = +10
-        project_manager.canvas.scan_dragto(event.x, event.y + delta_y, gain=1)
+            delta = scroll_delta * canvas_editing._abs_zoom_factor
+
+        shift_mask = 1 << 0  # Tkinter shift key bit
+        scroll_direction = "x" if (event.state & shift_mask) else "y"
+        dx, dy = (delta, 0) if scroll_direction == "x" else (0, delta)
+        project_manager.canvas.scan_dragto(int(event.x + dx), int(event.y + dy), gain=1)
         project_manager.grid_drawer.draw_grid()
 
     def _check_for_window_resize(self, _) -> None:


### PR DESCRIPTION
This adds:

* sidewise scrolling (when pressing shift)
* "View all" when pressing the home-key
* The scroll distance is now dependent on the zoom level.

(Some edge-cases are still not handled in a good way. For example when the mouse hovers over a item - the scrolling of the canvas stops).


