### PR TITLE
fix: verilog syntax highlighting

### DIFF
--- a/src/custom_text.py
+++ b/src/custom_text.py
@@ -809,17 +809,29 @@ class CustomText(CodeEditor):
         # Comment must be the last, because in the range of a comment all other tags are deleted:
         for text_ref in CustomText.read_variables_of_all_windows:
             text_ref.update_highlight_tags(project_manager.fontsize, ["not_read", "not_written", "comment"])
-        text_refs_fixed = [
-            project_manager.interface_generics_text,
-            project_manager.interface_package_text,
-            project_manager.interface_ports_text,
-            project_manager.internals_architecture_text,
-            project_manager.internals_process_clocked_text,
-            project_manager.internals_process_combinatorial_text,
-            project_manager.internals_package_text,
-        ]
-        for text_ref in text_refs_fixed:
+        for text_ref in _declaration_text_widgets():
             text_ref.update_highlight_tags(10, ["not_read", "not_written", "comment"])
+
+
+def _declaration_text_widgets():
+    """Text widgets that show HDL declarations (interface/internals). Used for language-aware highlighting."""
+    return [
+        project_manager.interface_generics_text,
+        project_manager.interface_package_text,
+        project_manager.interface_ports_text,
+        project_manager.internals_architecture_text,
+        project_manager.internals_process_clocked_text,
+        project_manager.internals_process_combinatorial_text,
+        project_manager.internals_package_text,
+    ]
+
+
+def refresh_highlighting_in_all_declaration_widgets() -> None:
+    """Reapply syntax highlighting in all declaration widgets (e.g. after language change)."""
+    tag_list = ["not_read", "not_written", "control", "datatype", "function", "comment"]
+    for text_ref in _declaration_text_widgets():
+        text_ref.update_highlight_tags(10, tag_list)
+    project_manager.highlight_dict_ref.recreate_keyword_list_of_unused_signals()
 
 
 def _remove_items_from_list(lst: list, items) -> None:

--- a/src/linting.py
+++ b/src/linting.py
@@ -2,6 +2,8 @@
 Methods needed for highlighting signals, which are not read, not written, not defined
 """
 
+import copy
+
 import constants
 import custom_text
 from elements import global_actions_combinatorial
@@ -16,7 +18,7 @@ class HighLightDict:
     """
 
     def __init__(self) -> None:
-        self.highlight_pattern_dict: dict[str, list[str]] = constants.VHDL_HIGHLIGHT_PATTERN_DICT
+        self.highlight_pattern_dict: dict[str, list[str]] = copy.deepcopy(constants.VHDL_HIGHLIGHT_PATTERN_DICT)
         self.recreate_after_id = None
         self.update_highlight_tags_id = None
 

--- a/src/tab_control.py
+++ b/src/tab_control.py
@@ -1,9 +1,13 @@
+"""Control-panel tab for project configuration (module name, language, paths, etc.)."""
+
+import copy
 import os
 import tkinter as tk
 from tkinter import ttk
 from tkinter.filedialog import askdirectory, askopenfilename
 
 import constants
+import custom_text
 import undo_handling
 from constants import GuiTab
 from dialogs.color_changer import ColorChanger
@@ -178,7 +182,11 @@ class TabControl:
     def switch_language_mode(self) -> None:  # also called from file_handling.py
         new_language = project_manager.language.get()
         if new_language == "VHDL":
-            project_manager.highlight_dict_ref.highlight_dict = constants.VHDL_HIGHLIGHT_PATTERN_DICT
+            project_manager.highlight_dict_ref.highlight_pattern_dict = copy.deepcopy(
+                constants.VHDL_HIGHLIGHT_PATTERN_DICT
+            )
+            project_manager.highlight_dict_ref.highlight_pattern_dict["not_read"].clear()
+            project_manager.highlight_dict_ref.highlight_pattern_dict["not_written"].clear()
             # enable 2 files mode
             project_manager.select_file_number_text.set(2)
             self._select_file_number_radio_button1.grid(row=0, column=2, sticky=tk.E)
@@ -206,7 +214,11 @@ class TabControl:
     = File with Entity and Architecture\n$name\t= Entity Name"
             )
         else:  # "Verilog" or "SystemVerilog"
-            project_manager.highlight_dict_ref.highlight_dict = constants.VERILOG_HIGHLIGHT_PATTERN_DICT
+            project_manager.highlight_dict_ref.highlight_pattern_dict = copy.deepcopy(
+                constants.VERILOG_HIGHLIGHT_PATTERN_DICT
+            )
+            project_manager.highlight_dict_ref.highlight_pattern_dict["not_read"].clear()
+            project_manager.highlight_dict_ref.highlight_pattern_dict["not_written"].clear()
             # Control: disable 2 files mode
             project_manager.select_file_number_text.set(1)
             self._select_file_number_radio_button1.grid_forget()
@@ -241,6 +253,8 @@ class TabControl:
             project_manager.compile_cmd_docu.config(
                 text="Variables for compile command:\n$file\t= Module-File\n$name\t= Module Name"
             )
+
+        custom_text.refresh_highlighting_in_all_declaration_widgets()
 
     def _show_path_has_changed(self) -> None:
         undo_handling.design_has_changed()


### PR DESCRIPTION
# Pull Request: Fix Verilog syntax highlighting

## Summary

Fixes Verilog keyword highlighting in Ports and other declaration widgets. Verilog/SystemVerilog pattern dict was not applied when switching language in tab control; this change applies it correctly and refreshes all declaration widgets on language change.

## Commit message

This fixes (Verilog keywords in Ports etc.

- Use highlight_pattern_dict (not highlight_dict) when switching language in tab_control so Verilog/SystemVerilog pattern dict is actually applied
- Initialize and assign deep copies of pattern dicts to avoid mutating constants
- Add refresh_highlighting_in_all_declaration_widgets() and call it on language change so Interface/Internals tabs update immediately (e.g. input, output, endcase)

## Changes

- **Use `highlight_pattern_dict` when switching language** — In tab control, use `highlight_pattern_dict` (not `highlight_dict`) so the Verilog/SystemVerilog pattern dictionary is actually applied.
- **Deep copies of pattern dicts** — Initialize and assign deep copies of pattern dicts to avoid mutating shared constants.
- **Refresh on language change** — Add `refresh_highlighting_in_all_declaration_widgets()` and call it on language change so Interface/Internals tabs (e.g. `input`, `output`, `endcase`) update immediately.
